### PR TITLE
Fixes pre-commit install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
   # Ensure that npm version is 6.4.1
   - if [[ `npm -v` != 6.4.1 ]]; then npm i -g npm@6.4.1; fi
   # Install pre-commit (locking pyyaml to a specific version b/c of compilation issues)
+  - pip3 install setuptools
   - pip3 install --user 'pyyaml>=3.12' pre-commit pathlib2
   - export PATH=$PATH:$HOME/.local/bin
 


### PR DESCRIPTION
I fixed this bug in Penumbra and noticed it in here too.

Installs `setuptools` In Travis before `pre-commit` install. Must've been a breaking change in one of these libs.