### PR TITLE
changes limit logic to not use default

### DIFF
--- a/src/utils/batchProcess.ts
+++ b/src/utils/batchProcess.ts
@@ -52,7 +52,7 @@ export default async function batchProcess<
     where = '',
     attributes = '*',
     limit = 1000,
-    orderBy = '"createdAt" ASC',
+    orderBy = 'id',
   } = whereOptions;
   let offset = 0;
   let remaining = true;

--- a/src/utils/batchProcess.ts
+++ b/src/utils/batchProcess.ts
@@ -84,7 +84,7 @@ export default async function batchProcess<
     processed += rows.length;
 
     // Update
-    offset += 1000;
+    offset += limit;
     remaining = rows.length === limit;
 
     // Log when the processing takes a long time


### PR DESCRIPTION
Bug fix - limit was being overwritten by its default = 1000
Better default - default orders the batch by id, which fixes errors caused when createdAt is identical for multiple rows.