### PR TITLE
Model definitions consolidating to definition.ts and hooks.ts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "cSpell.words": [
+    "backoff",
     "camelcase",
     "conname",
     "connamespace",

--- a/fix_absolute_imports.js
+++ b/fix_absolute_imports.js
@@ -1,4 +1,4 @@
-// external modules
+// external
 const { join } = require('path');
 const { readFileSync, writeFileSync } = require('fs');
 const glob = require('glob');

--- a/generators/generators/migration/index.ts
+++ b/generators/generators/migration/index.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { paramCase } from 'change-case';
 
 // global

--- a/generators/index.ts
+++ b/generators/index.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import difference from 'lodash/difference';
 import kebabCase from 'lodash/kebabCase';
 

--- a/generators/migrationTypes/tableColumnMigration/lib.ts
+++ b/generators/migrationTypes/tableColumnMigration/lib.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import flatten from 'lodash/flatten';
 
 // migrationTypes

--- a/generators/migrationTypes/tablesColumnMigration/index.ts
+++ b/generators/migrationTypes/tablesColumnMigration/index.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import intersection from 'lodash/intersection';
 
 // migrationTypes

--- a/generators/migrations/bulkDelete/template.hbs
+++ b/generators/migrations/bulkDelete/template.hbs
@@ -1,5 +1,5 @@
 {{> dbMigrationHeader }}
-// external modules
+// external
 import uuidv4 from 'uuid/v4';
 
 // wildebeest

--- a/generators/migrations/bulkInsert/template.hbs
+++ b/generators/migrations/bulkInsert/template.hbs
@@ -1,5 +1,5 @@
 {{> dbMigrationHeader }}
-// external modules
+// external
 import uuidv4 from 'uuid/v4';
 
 // wildebeest

--- a/generators/migrations/changeOnDelete/index.ts
+++ b/generators/migrations/changeOnDelete/index.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import kebabCase from 'lodash/kebabCase';
 
 // global

--- a/generators/migrations/renameConstraint/index.ts
+++ b/generators/migrations/renameConstraint/index.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import kebabCase from 'lodash/kebabCase';
 
 /**

--- a/mixins/ChangeCase.ts
+++ b/mixins/ChangeCase.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import camelCase from 'lodash/camelCase';
 import pluralize from 'pluralize';
 

--- a/mixins/Handlebars.ts
+++ b/mixins/Handlebars.ts
@@ -2,7 +2,7 @@
  * Creates the handlebars instance
  */
 
-// external modules
+// external
 import Handlebars from 'handlebars';
 
 // helpers

--- a/mixins/convert_paths.ts
+++ b/mixins/convert_paths.ts
@@ -21,7 +21,7 @@
  * @author awendland
  */
 
-// external modules
+// external
 import fs from 'fs';
 import { join } from 'path';
 

--- a/mixins/helpers/createBase.ts
+++ b/mixins/helpers/createBase.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { writeFileSync } from 'fs';
 import { join } from 'path';
 

--- a/mixins/helpers/createCompilerHost.ts
+++ b/mixins/helpers/createCompilerHost.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { join } from 'path';
 import * as ts from 'typescript';
 

--- a/mixins/helpers/extractAssociationDefinitions.ts
+++ b/mixins/helpers/extractAssociationDefinitions.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import * as ts from 'typescript';
 
 // mixins

--- a/mixins/helpers/getCompilerOptions.ts
+++ b/mixins/helpers/getCompilerOptions.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import * as fs from 'fs';
 import { join } from 'path';
 import { CompilerOptions } from 'typescript';

--- a/mixins/helpers/indexPaths.ts
+++ b/mixins/helpers/indexPaths.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { CompilerOptions } from 'typescript';
 
 /**

--- a/mixins/helpers/pascalCase.ts
+++ b/mixins/helpers/pascalCase.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import camelCase from 'lodash/camelCase';
 import upperFirst from 'lodash/upperFirst';
 

--- a/mixins/helpers/serializeAssociationType.ts
+++ b/mixins/helpers/serializeAssociationType.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import get from 'lodash/get';
 
 // global

--- a/mixins/helpers/setConfigDefaults.ts
+++ b/mixins/helpers/setConfigDefaults.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { join } from 'path';
 import pluralize from 'pluralize';
 

--- a/mixins/index.ts
+++ b/mixins/index.ts
@@ -4,7 +4,7 @@
 import './convert_paths';
 
 /* tslint:disable no-relative-imports */
-// external modules
+// external
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/wildebeest",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "description": "Type-safe sequelize with a simplified migration framework",
   "main": "build/src/index.js",
   "homepage": "https://github.com/transcend-io/wildebeest#readme",

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console,class-methods-use-this */
-// external modules
+// external
 /* tslint:disable no-var-requires */
 const chalk = require('chalk'); // eslint-disable-line @typescript-eslint/no-var-requires
 /* tslint:enable no-var-requires */

--- a/src/checks/allowNullConstraint.ts
+++ b/src/checks/allowNullConstraint.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { ModelAttributeColumnOptions } from 'sequelize';
 
 // global

--- a/src/checks/associationConfig.ts
+++ b/src/checks/associationConfig.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { QueryTypes } from 'sequelize';
 
 // global

--- a/src/checks/associations.ts
+++ b/src/checks/associations.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import flatten from 'lodash/flatten';
 
 // global

--- a/src/checks/columnDefinitions.ts
+++ b/src/checks/columnDefinitions.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import difference from 'lodash/difference';
 import uniq from 'lodash/uniq';
 

--- a/src/checks/columnType.ts
+++ b/src/checks/columnType.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { ModelAttributeColumnOptions, QueryTypes } from 'sequelize';
 
 // global

--- a/src/checks/defaultValue.ts
+++ b/src/checks/defaultValue.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { ModelAttributeColumnOptions } from 'sequelize';
 
 // classes

--- a/src/checks/enumDefinition.ts
+++ b/src/checks/enumDefinition.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import difference from 'lodash/difference';
 import { ModelAttributeColumnOptions, QueryTypes } from 'sequelize';
 

--- a/src/checks/indexes.ts
+++ b/src/checks/indexes.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import difference from 'lodash/difference';
 import uniq from 'lodash/uniq';
 import { ModelAttributeColumnOptions, QueryTypes } from 'sequelize';

--- a/src/checks/primaryKeyDefinition.ts
+++ b/src/checks/primaryKeyDefinition.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { QueryTypes } from 'sequelize';
 
 // global

--- a/src/checks/uniqueConstraint.ts
+++ b/src/checks/uniqueConstraint.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { ModelAttributeColumnOptions, QueryTypes } from 'sequelize';
 
 // global

--- a/src/classes/Wildebeest.ts
+++ b/src/classes/Wildebeest.ts
@@ -3,7 +3,7 @@
  * The main migration runner and checking class definition
  */
 
-// external modules
+// external
 import { S3 } from 'aws-sdk';
 import * as express from 'express';
 import { existsSync, readdirSync } from 'fs';

--- a/src/classes/WildebeestDb.ts
+++ b/src/classes/WildebeestDb.ts
@@ -2,7 +2,7 @@
  * A modified sequelize database class with helper functions useful to wildebeest
  */
 
-// external modules
+// external
 import {
   DataTypes,
   Options,

--- a/src/classes/WildebeestModel.ts
+++ b/src/classes/WildebeestModel.ts
@@ -1,6 +1,6 @@
 /* eslint-disable-line max-lines */
 
-// external modules
+// external
 import * as Bluebird from 'bluebird';
 import { Model, ModelOptions, Op } from 'sequelize';
 import { ModelHooks } from 'sequelize/types/lib/hooks';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { snakeCase } from 'change-case';
 import { ModelIndexesOptions } from 'sequelize';
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import * as express from 'express';
 
 // global

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
  * Migration files for migrating the db using Sequelize and Umzug
  */
 
-// external modules
+// external
 import { DataTypes } from 'sequelize';
 
 // local

--- a/src/migrationTypes/addColumns.ts
+++ b/src/migrationTypes/addColumns.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-// external modules
+// external
 import difference from 'lodash/difference';
 import { DataType, ModelAttributeColumnOptions, WhereOptions } from 'sequelize';
 

--- a/src/migrationTypes/addEnumValues.ts
+++ b/src/migrationTypes/addEnumValues.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import difference from 'lodash/difference';
 import uniq from 'lodash/uniq';
 

--- a/src/migrationTypes/addUniqueConstraintIndex.ts
+++ b/src/migrationTypes/addUniqueConstraintIndex.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import flatten from 'lodash/flatten';
 
 // global

--- a/src/migrationTypes/changeColumn.ts
+++ b/src/migrationTypes/changeColumn.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { ModelAttributeColumnOptions } from 'sequelize';
 
 // global

--- a/src/migrationTypes/convertEnumValues.ts
+++ b/src/migrationTypes/convertEnumValues.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import difference from 'lodash/difference';
 import flatten from 'lodash/flatten';
 

--- a/src/migrationTypes/removeNonNullColumn.ts
+++ b/src/migrationTypes/removeNonNullColumn.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { ModelAttributeColumnOptions } from 'sequelize';
 
 // global

--- a/src/migrationTypes/renameEnumValue.ts
+++ b/src/migrationTypes/renameEnumValue.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import difference from 'lodash/difference';
 
 // global

--- a/src/migrationTypes/renameS3Files.ts
+++ b/src/migrationTypes/renameS3Files.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { S3 } from 'aws-sdk';
 
 // global

--- a/src/mixins/index.ts
+++ b/src/mixins/index.ts
@@ -3,7 +3,7 @@
  * Mixin prototypes to attach to each model instance in addition to the sequelize mixins
  */
 
-// external modules
+// external
 import pluralize from 'pluralize';
 import { FindOptions } from 'sequelize';
 

--- a/src/mixins/types.ts
+++ b/src/mixins/types.ts
@@ -4,7 +4,7 @@
  * TODO options undefined handling
  */
 
-// external modules
+// external
 import {
   BelongsToCreateAssociationMixinOptions,
   BelongsToGetAssociationMixin,

--- a/src/models/migration/Migration.ts
+++ b/src/models/migration/Migration.ts
@@ -2,7 +2,7 @@
  * A database model for a Migration request.
  */
 
-// external modules
+// external
 import {
   DownToOptions,
   ExecuteOptions,
@@ -16,21 +16,16 @@ import { ExtractAttributes, ModelMap, UpToOptions } from '@wildebeest/types';
 import logSection from '@wildebeest/utils/logSection';
 
 // local
-import attributes from './attributes';
-import * as options from './options';
+import definition from './definition';
 
 /**
  * A Migration db model
  */
 export default class Migration<TModels extends ModelMap>
   extends WildebeestModel<TModels>
-  implements ExtractAttributes<typeof attributes> {
+  implements ExtractAttributes<typeof definition['attributes']> {
   /** The model definition */
-  public static definition = {
-    attributes,
-    options,
-    tableName: 'migrations',
-  };
+  public static definition = definition;
 
   /** The current batch number to add */
   public static batch: number;

--- a/src/models/migration/definition.ts
+++ b/src/models/migration/definition.ts
@@ -1,13 +1,16 @@
-// external modules
+// external
 import { DataTypes } from 'sequelize';
 
 // global
 import createAttributes from '@wildebeest/utils/createAttributes';
 
+// local
+import hooks from './hooks';
+
 /**
  * Attribute definitions for the model
  */
-const ATTRIBUTES = createAttributes({
+const attributes = createAttributes({
   /** The id is an integer */
   id: {
     autoIncrement: true,
@@ -26,4 +29,10 @@ const ATTRIBUTES = createAttributes({
     unique: 'name must be unique',
   },
 });
-export default ATTRIBUTES;
+
+// Model definition
+export default {
+  attributes,
+  options: { hooks },
+  tableName: 'migrations',
+};

--- a/src/models/migration/index.ts
+++ b/src/models/migration/index.ts
@@ -2,10 +2,4 @@
  * A database model for a Migration request.
  */
 
-// local
-import Migration from './Migration';
-
-/**
- * A Migration db model
- */
-export default Migration;
+export { default } from './Migration';

--- a/src/models/migrationLock/MigrationLock.ts
+++ b/src/models/migrationLock/MigrationLock.ts
@@ -2,7 +2,7 @@
  * A database model for a MigrationLock request.
  */
 
-// external modules
+// external
 import { Transaction } from 'sequelize';
 
 // global
@@ -18,19 +18,16 @@ import Migration from '@wildebeest/models/migration/Migration';
 import { ExtractAttributes, ModelMap } from '@wildebeest/types';
 
 // local
-import attributes from './attributes';
+import definition from './definition';
 
 /**
  * A MigrationLock db model
  */
 export default class MigrationLock<TModels extends ModelMap>
   extends WildebeestModel<TModels>
-  implements ExtractAttributes<typeof attributes> {
+  implements ExtractAttributes<typeof definition['attributes']> {
   /** The model definition */
-  public static definition = {
-    attributes,
-    tableName: 'migrationLocks',
-  };
+  public static definition = definition;
 
   /**
    * Lock the migrations so no one else attempts to migrate the db at the same time.

--- a/src/models/migrationLock/definition.ts
+++ b/src/models/migrationLock/definition.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { DataTypes } from 'sequelize';
 
 // global
@@ -7,7 +7,7 @@ import createAttributes from '@wildebeest/utils/createAttributes';
 /**
  * Attribute definitions for the model
  */
-const ATTRIBUTES = createAttributes({
+const attributes = createAttributes({
   /** Indicates that the migrator should be locked because another instance is running the migrations. */
   isLocked: {
     allowNull: false,
@@ -16,4 +16,9 @@ const ATTRIBUTES = createAttributes({
     unique: 'isLocked must be unique',
   },
 });
-export default ATTRIBUTES;
+
+// Model definition
+export default {
+  attributes,
+  tableName: 'migrationLocks',
+};

--- a/src/models/migrationLock/index.ts
+++ b/src/models/migrationLock/index.ts
@@ -2,10 +2,4 @@
  * A database model for a MigrationLock request.
  */
 
-// local
-import MigrationLock from './MigrationLock';
-
-/**
- * A MigrationLock db model
- */
-export default MigrationLock;
+export { default } from './MigrationLock';

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2,7 +2,7 @@
  * Routes for running migrations
  */
 
-// external modules
+// external
 import express from 'express';
 
 // local

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-// external modules
+// external
 import * as express from 'express';
 import * as sequelize from 'sequelize';
 import { HookReturn, ModelHooks } from 'sequelize/types/lib/hooks';

--- a/src/utils/addTableColumnConstraint.ts
+++ b/src/utils/addTableColumnConstraint.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import sequelize from 'sequelize';
 
 // global

--- a/src/utils/batchProcess.ts
+++ b/src/utils/batchProcess.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { QueryTypes } from 'sequelize';
 
 // global

--- a/src/utils/clearSchema.ts
+++ b/src/utils/clearSchema.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import sequelize from 'sequelize';
 
 /**

--- a/src/utils/columnAllowsNull.ts
+++ b/src/utils/columnAllowsNull.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { QueryTypes } from 'sequelize';
 
 // global

--- a/src/utils/configureModelDefinition.ts
+++ b/src/utils/configureModelDefinition.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import transform from 'lodash/transform';
 
 // global

--- a/src/utils/createHooks.ts
+++ b/src/utils/createHooks.ts
@@ -1,0 +1,18 @@
+// external
+import { ModelHooks } from 'sequelize/types/lib/hooks';
+
+// global
+import { WildebeestModel } from '@wildebeest/classes';
+import { ModelMap } from '@wildebeest/types';
+
+/**
+ * Create database model hooks for a db model
+ *
+ * @param hooks - The hooks
+ * @returns The type-enforced hooks
+ */
+export default function createHooks<TModel extends WildebeestModel<ModelMap>>(
+  hooks: Partial<ModelHooks<TModel>>,
+): Partial<ModelHooks<TModel>> {
+  return hooks;
+}

--- a/src/utils/createQueryMaker.ts
+++ b/src/utils/createQueryMaker.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import * as sequelize from 'sequelize';
 
 // global

--- a/src/utils/freshIndexes.ts
+++ b/src/utils/freshIndexes.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { ModelOptions } from 'sequelize';
 
 /**

--- a/src/utils/getAssociationAttribute.ts
+++ b/src/utils/getAssociationAttribute.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import * as sequelize from 'sequelize';
 
 // global

--- a/src/utils/getColumnDefault.ts
+++ b/src/utils/getColumnDefault.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { QueryTypes } from 'sequelize';
 
 // global

--- a/src/utils/getForeignKeyConfig.ts
+++ b/src/utils/getForeignKeyConfig.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { QueryTypes } from 'sequelize';
 
 // global

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,6 +12,7 @@ export { default as configureAssociations } from './configureAssociations';
 export { default as configureModelDefinition } from './configureModelDefinition';
 export { default as createAssociationApply } from './createAssociationApply';
 export { default as createAttributes } from './createAttributes';
+export { default as createHooks } from './createHooks';
 export { default as createAssociationApplyValue } from './createAssociationApplyValue';
 export { default as createIndex } from './createIndex';
 export { default as createUmzugLogger } from './createUmzugLogger';

--- a/src/utils/indexConstraints.ts
+++ b/src/utils/indexConstraints.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import keyBy from 'lodash/keyBy';
 
 /**

--- a/src/utils/inferTableReference.ts
+++ b/src/utils/inferTableReference.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import camelCase from 'lodash/camelCase';
 
 /**

--- a/src/utils/listColumns.ts
+++ b/src/utils/listColumns.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { QueryTypes } from 'sequelize';
 
 // global

--- a/src/utils/listConstraintNames.ts
+++ b/src/utils/listConstraintNames.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { QueryTypes } from 'sequelize';
 
 // global

--- a/src/utils/listEnumAttributes.ts
+++ b/src/utils/listEnumAttributes.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { QueryTypes } from 'sequelize';
 
 // global

--- a/src/utils/listIndexNames.ts
+++ b/src/utils/listIndexNames.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { QueryTypes } from 'sequelize';
 
 // global

--- a/src/utils/migrateEnumColumn.ts
+++ b/src/utils/migrateEnumColumn.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { Op } from 'sequelize';
 
 // global

--- a/src/utils/pascalCase.ts
+++ b/src/utils/pascalCase.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import camelCase from 'lodash/camelCase';
 import upperFirst from 'lodash/upperFirst';
 

--- a/src/utils/renameS3File.ts
+++ b/src/utils/renameS3File.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { S3 } from 'aws-sdk';
 
 // global

--- a/src/utils/restoreFromDump.ts
+++ b/src/utils/restoreFromDump.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { execSync } from 'child_process';
 
 // global

--- a/src/utils/tableExists.ts
+++ b/src/utils/tableExists.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { QueryTypes, Sequelize, Transaction } from 'sequelize';
 
 /**

--- a/src/utils/writeSchema.ts
+++ b/src/utils/writeSchema.ts
@@ -1,4 +1,4 @@
-// external modules
+// external
 import { execSync } from 'child_process';
 import { copyFileSync } from 'fs';
 

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -2,7 +2,7 @@
  * Handlebars templates used for the running wildebeest migrations.
  */
 
-// external modules
+// external
 import { readFileSync } from 'fs';
 import Handlebars from 'handlebars';
 


### PR DESCRIPTION
- Comment for `external modules` -> `external`
- Consolidates `associations.ts`, `attributes.ts` and `options.ts` files into `definition.ts` and `hooks.ts` files to reduce sprawl

[see an example](https://github.com/transcend-io/wildebeest/pull/62/files#diff-7d14e33b999469709cb469d179500039R1-R38)