### PR TITLE
Genesis migration handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/wildebeest",
-  "version": "2.15.13",
+  "version": "2.15.14",
   "description": "Type-safe sequelize with a simplified migration framework",
   "main": "build/src/index.js",
   "homepage": "https://github.com/transcend-io/wildebeest#readme",


### PR DESCRIPTION
Logic was still off :( if db was not fully migrated, it would try to restore the genesis migration.

I tried to simplify the logic a bit to make it more clear what's going on